### PR TITLE
731 - Connect to Rabbit MQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,14 @@ curl --header "Content-Type: application/json" \
      --data '{"model_class":"SimpleExampleEtl"}'  \
      --request POST http://0.0.0.0:2345/api/0.01/task
 ```
+
+
+### Distributed (but still local) processing
+
+TODO
+
+```shell
+curl --header "Content-Type: application/json" \
+     --data '{"model_class":"PartitionedExampleEtl"}'  \
+     --request POST http://0.0.0.0:2345/api/0.01/task
+```

--- a/fossa/control/governor.py
+++ b/fossa/control/governor.py
@@ -267,8 +267,11 @@ class Governor:
 
                 print(f"governor {governor_id} see completion of ", task_spec)
 
+                # either a fail or complete message
+                final_task_message = result_spec.task_message
+
                 # TODO - external code - wrap in try except
-                task_spec.on_completion_callback(result_spec, task_spec)
+                task_spec.on_completion_callback(final_task_message, task_spec)
 
                 # Remove from processing table but keep a log of finished tasks
                 previous_tasks.append(process_details)

--- a/fossa/control/message.py
+++ b/fossa/control/message.py
@@ -13,7 +13,7 @@ class TaskMessage(AbstractMessage):
     method: str
     method_kwargs: dict
     resolver_context: dict
-    on_completion_callback: Callable
+    on_completion_callback: Callable  # takes final_task_message (str), task_spec (this TaskMessage)
     task_id: Optional[str] = None
 
 
@@ -24,7 +24,7 @@ class ResultsMessage(AbstractMessage):
     """
 
     task_id: str
-    result: Any
+    task_message: Any  # subclass obj. of :class:`ayeaye.runtime.task_message.AbstractTaskMessage`
 
 
 @dataclass

--- a/fossa/control/rabbit_mq/process.py
+++ b/fossa/control/rabbit_mq/process.py
@@ -1,9 +1,5 @@
-import traceback
-import sys
-
 import ayeaye
 
-from fossa.control.message import ResultsMessage
 from fossa.control.process import AbstractIsolatedProcessor
 from fossa.control.rabbit_mq.process_pool import RabbitMqProcessPool
 
@@ -29,49 +25,16 @@ class RabbitMqProcessor(AbstractIsolatedProcessor):
         self.broker_url = kwargs.pop("broker_url")
         super().__init__(*args, **kwargs)
 
-    def __call__(self, task_id, model_cls, method, method_kwargs, resolver_context):
+    def on_model_start(self, model):
         """
-        Run/execute the model. This method runs in a separate process.
-
-        @see doc. string in :meth:`AbstractAyeAyeProcess.__call__`.
+        @see :meth:`AbstractIsolatedProcessor.on_model_start` for doc. string.
         """
+        model_cls = model.__class__
+        if issubclass(model_cls, ayeaye.PartitionedModel):
+            # Only :meth:`_build` in a `PartitionedModel` can yield tasks but the message
+            # passing is rightly or wrongly being setup for all methods.
+            model.process_pool = RabbitMqProcessPool(broker_url=self.broker_url)
 
-        try:
-            with ayeaye.connector_resolver.context(**resolver_context):
-                model = model_cls()
-
-                if issubclass(model_cls, ayeaye.PartitionedModel):
-                    # Only :meth:`_build` in a `PartitionedModel` can yield tasks but the message
-                    # passing is rightly or wrongly being setup for all methods.
-                    model.process_pool = RabbitMqProcessPool(broker_url=self.broker_url)
-
-                    # TODO - This should include info on how many workers there are in the pool
-                    # for now, just set this to anything so it's not confused with local CPU counts
-                    model.runtime.max_concurrent_tasks = 128
-
-                sub_task_method = getattr(model, method)
-                subtask_return_value = sub_task_method(**method_kwargs)
-
-                result_spec = ResultsMessage(
-                    task_id=task_id,
-                    result={"return_value": subtask_return_value},
-                )
-
-        except Exception as e:
-            # TODO - this is a bit rough
-
-            _e_type, _e_value, e_traceback = sys.exc_info()
-            traceback_ln = []
-            tb_list = traceback.extract_tb(e_traceback)
-            for filename, line, funcname, text in tb_list:
-                traceback_ln.append(f"Traceback:  File[{filename}] Line[{line}] Text[{text}]")
-
-            result_spec = ResultsMessage(
-                task_id=task_id,
-                result={
-                    "exception": str(type(e)) + " : " + str(e),
-                    "traceback": "\n".join(traceback_ln),
-                },
-            )
-
-        self.work_queue.put(result_spec)
+            # TODO - This should include info on how many workers there are in the pool
+            # for now, just set this to anything so it's not confused with local CPU counts
+            model.runtime.max_concurrent_tasks = 128

--- a/fossa/views/web.py
+++ b/fossa/views/web.py
@@ -24,7 +24,7 @@ def index():
         summary = asdict(t["task_spec"])
         summary["started"] = t["started"]
         summary["finished"] = t["finished"]
-        summary["results"] = t["result_spec"].result
+        summary["results"] = t["result_spec"].task_message
         previous_tasks.append(summary)
 
     page_vars = {


### PR DESCRIPTION
refined: better use of object based messages instead of json
changed: args to governor executed callback
removed: ResultsMessage.result
added: ResultsMessage.task_message - instance of :class:`ayeaye.runtime.task_message.AbstractTaskMessage` updated: AbstractIsolatedProcessor to do more of the work, subclasses get `on_model_start` to fixup the mo del before it runs