### PR TITLE
Distributed logging

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ flask = "*"
 gunicorn = "*"
 ayeaye = "*"
 pika = "*"
+boto3 = "*"
 
 [dev-packages]
 

--- a/fossa/app.py
+++ b/fossa/app.py
@@ -55,6 +55,11 @@ def single_config_initialise(flask_config):
     governor = Governor()
     app = create_app(flask_config, governor)
 
+    governor.log_to_stdout = app.config["LOG_TO_STDOUT"]
+
+    for logger in app.config.get("EXTERNAL_LOGGERS", []):
+        governor.attach_external_logger(logger)
+
     for model_cls in app.config["ACCEPTED_MODEL_CLASSES"]:
         governor.set_accepted_class(model_cls)
 

--- a/fossa/control/broker.py
+++ b/fossa/control/broker.py
@@ -1,15 +1,29 @@
 import time
 
 from fossa.control.message import TaskMessage
+from fossa.tools.logging import LoggingMixin
 
 
-class AbstractMycorrhiza:
+class AbstractMycorrhiza(LoggingMixin):
     """
     A separate 'sidecar' process that is attached to the :class:`Governor` primarily to inject
     work tasks.
+
+    The objective for sidecars are to (i) take details on sub-tasks that need to be run from an
+    external source (e.g. a messaging service) (ii) send the sub-task to the governor to run
+    and (iii) send results back to the originating task (iv) send log messages somewhere useful.
+
+    The :meth:`run_forever` is executed in a separate process. It is provided with the governor's
+    task queue onto which it submits subtasks. It is also provided with a shared variable used to
+    indicate if the governor has capacity to accept additional work.
+
+    Just before execution of the sidecar starts the govenor will attach external logger modules
+    if there are any. Log messages from sidecars are separate from the log messages generated
+    by models.
     """
 
     def __init__(self):
+        LoggingMixin.__init__(self)
         self.work_queue_submit = None
         self.available_processing_capacity = None
 

--- a/fossa/control/rabbit_mq/process.py
+++ b/fossa/control/rabbit_mq/process.py
@@ -35,6 +35,10 @@ class RabbitMqProcessor(AbstractIsolatedProcessor):
             # passing is rightly or wrongly being setup for all methods.
             model.process_pool = RabbitMqProcessPool(broker_url=self.broker_url)
 
+            # Both RabbitMqProcessor and RabbitMqProcessPool use the LoggingMixin so share the
+            # logging setup
+            model.process_pool.copy_logging_setup(self)
+
             # TODO - This should include info on how many workers there are in the pool
             # for now, just set this to anything so it's not confused with local CPU counts
             model.runtime.max_concurrent_tasks = 128

--- a/fossa/settings/global_config.py
+++ b/fossa/settings/global_config.py
@@ -6,3 +6,5 @@ class BaseConfig:
     HTTP_PORT = 2345
     ACCEPTED_MODEL_CLASSES = []  # iterable of classes that the node is authorised to run
     MESSAGE_BROKER_MANAGERS = []  # subclasses of  to run in a separate process
+    EXTERNAL_LOGGERS = []  # subclasses of
+    LOG_TO_STDOUT = True  # i.e. print out log messages

--- a/fossa/tools/logging.py
+++ b/fossa/tools/logging.py
@@ -1,0 +1,74 @@
+import copy
+from datetime import datetime
+
+
+class AbstractExternalLogger:
+    """
+    External loggers can be used alongside or instead of writing log messages to STDOUT.
+    """
+
+    def write(self, msg, level="INFO"):
+        """
+        @param msg: (str)
+        @param level: (str)
+        @return: bool for success to log
+        """
+        raise NotImplementedError("Must be implemented by subclasses")
+
+
+class LoggingMixin:
+    """
+    Additional methods to log system information to the stdout (i.e. print) or to external
+    logging services such as CloudWatch Logs.
+    """
+
+    def __init__(self):
+        # @see :meth:`attach_external_logger`
+        self.external_loggers = []
+
+        # publically settable
+        self.log_to_stdout = True
+
+    def attach_external_logger(self, logger):
+        """
+        @param logger (subclass of :class:`AbstractExternalLogger`):
+        """
+        assert isinstance(logger, AbstractExternalLogger)
+        self.external_loggers.append(logger)
+
+    def copy_logging_setup(self, logging_mixin_obj):
+        """
+        Take all the logging info from another subclass of :class:`LoggingMixin` and use it here.
+        """
+        self.log_to_stdout = logging_mixin_obj.log_to_stdout
+
+        # pass any external loggers on
+        for logger in logging_mixin_obj.external_loggers:
+            # use a copy just incase there is any multiprocessing 'fun' around weak refs
+            # or lack of concurrency support
+            self.attach_external_logger(copy.copy(logger))
+
+    def log(self, message, level="INFO"):
+        """
+        @param message: (str)
+        @param level: (str) - standard POSIX levels - DEBUG, INFO, ERROR, CRITICAL etc.
+        """
+        if self.log_to_stdout:
+            date_str = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+            msg = "{} {}{}".format(date_str, level.ljust(10), message)
+            print(msg)
+
+        for logger in self.external_loggers:
+            if not logger.write(msg=message, level=level) and self.log_to_stdout:
+                date_str = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+                msg = "{} {}External logger failed".format(date_str, level.ljust(10), message)
+                print(msg)
+
+
+class MiniLogger(LoggingMixin):
+    """
+    Standalone logger which is useful within isolated processes. Using this keeps the interface
+    consistent with other classes that implement the `LoggingMixin`.
+    """
+
+    pass

--- a/fossa/tools/logging_cloudwatch.py
+++ b/fossa/tools/logging_cloudwatch.py
@@ -1,0 +1,90 @@
+import json
+import time
+
+import boto3
+
+from fossa.tools.logging import AbstractExternalLogger
+
+
+class CloudwatchLogs(AbstractExternalLogger):
+    """
+    Send structured log messages to AWS' Cloudwatch logs facility.
+
+    Install boto3 (`pip install boto3`) to use this.
+
+    See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html
+
+    If you are using the one config file way to run Fossa, add an instance of this class to your
+    config in the `EXTERNAL_LOGGERS` list.
+    """
+
+    def __init__(self, group_name, stream_name, region_name):
+        """
+        @param group_name: (str) - AWS cloudwatch logs's group name - must exist before running this
+        @param stream_name: (str) - AWS cloudwatch logs's group name - must exist before running this
+        @param region_name: (str) - AWS region, e.g. "eu-west-2"
+        """
+        self.group_name = group_name
+        self.stream_name = stream_name
+        self.region_name = region_name
+
+        # lazy
+        self._client = None
+
+    def __getstate__(self):
+        "Pickle safe so this logger can be moved between processes."
+        return dict(
+            group_name=self.group_name,
+            stream_name=self.stream_name,
+            region_name=self.region_name,
+        )
+
+    def __setstate__(self, state):
+        "Pickle safe so this logger can be moved between processes."
+        self.group_name = state["group_name"]
+        self.stream_name = state["stream_name"]
+        self.region_name = state["region_name"]
+        self._client = None
+
+    def __copy__(self):
+        """
+        Not sure how concurrency safe the boto3 client is so keep it safe by allowing explicit
+        copying to create an independent version without the initalised boto3 client.
+        """
+        c = self.__class__(
+            group_name=self.group_name,
+            stream_name=self.stream_name,
+            region_name=self.region_name,
+        )
+        return c
+
+    @property
+    def client(self):
+        "boto3 client for cloudwatch logs"
+
+        if self._client is None:
+            self._client = boto3.client("logs", region_name=self.region_name)
+        return self._client
+
+    def write(self, msg, level="INFO"):
+        "Send a message to Cloudwatch logs"
+
+        structured_log = {
+            "log_level": level,
+            "message": msg,
+        }
+        serialised_msg = json.dumps(structured_log)
+
+        response = self.client.put_log_events(
+            logGroupName=self.group_name,
+            logStreamName=self.stream_name,
+            logEvents=[
+                {
+                    "timestamp": int(time.time() * 1000),  # milliseconds
+                    "message": serialised_msg,
+                },
+            ],
+        )
+
+        # did the log work?
+        return response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 200

--- a/tests/base.py
+++ b/tests/base.py
@@ -19,6 +19,7 @@ class BaseTest(unittest.TestCase):
 
         # internal process not started
         self.governor = Governor()
+        self.governor.log_to_stdout = False
 
         self.app = create_app(self.config, self.governor)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,50 @@
+import multiprocessing
+
+from fossa.control.broker import AbstractMycorrhiza
+from fossa.control.message import TerminateMessage
+from fossa.tools.logging import AbstractExternalLogger
+
+from tests.base import BaseTest
+
+
+class QueueLogger(AbstractExternalLogger):
+    def __init__(self, log_queue):
+        self.log_queue = log_queue
+
+    def write(self, msg, level="INFO"):
+        self.log_queue.put(f"{level} {msg}")
+        return True
+
+
+class FakeSideCar(AbstractMycorrhiza):
+    def run_forever(self, work_queue_submit, available_processing_capacity):
+        self.log("This is the fake sidecar")
+
+
+class TestLogging(BaseTest):
+    def test_external_logger_is_passed(self):
+        """
+        The logging setup should be passed to every object that subclasses LoggingMixin when the
+        object is joined to the governor. This test just checks one sidecar.
+        """
+        log_queue = multiprocessing.Queue()
+        fake_logger = QueueLogger(log_queue=log_queue)
+
+        self.governor.attach_sidecar(FakeSideCar())
+        self.governor.attach_external_logger(fake_logger)
+        self.governor.log_to_stdout = False
+
+        proc = self.governor.start_internal_processes()
+
+        # instruct the governor to stop
+        self.governor._task_queue_submit.put(TerminateMessage())
+
+        # wait for it to terminate
+        proc.join()
+
+        all_the_logs = []
+        while not log_queue.empty():
+            log_msg = log_queue.get()
+            all_the_logs.append(log_msg)
+
+        self.assertIn("INFO This is the fake sidecar", all_the_logs)


### PR DESCRIPTION
System logs from all the parts of Fossa can be sent directly back to Cloudwatch logs if the config file states that. All log messages from sub-tasks go back to the originating model.

added: LOG_TO_STDOUT config option
added: AbstractExternalLogger - to define external logging modules
added: LoggingMixin so a variety of classes in Fossa can share the logging setup
updated: governor to pass the logging setup to processes and subsystems where possible